### PR TITLE
Dev

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
+^LICENSE\.md$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^output$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: psychTestR
 Type: Package
 Title: Framework for delivering psychological tests via Shiny
-Version: 2.0.2
+Version: 2.0.3
 Author: Peter M. C. Harrison
 Maintainer: Peter M. C. Harrison <pmc.harrison@gmail.com>
 Description: Framework for delivering psychological tests via Shiny.

--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
 YEAR: 2018
-COPYRIGHT HOLDER: Peter M. C. Harrison (pmc.harrison@gmail.com)
+COPYRIGHT HOLDER: Peter M. C. Harrison

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2018 Peter M. C. Harrison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+* Bugfix - Implicit timeline creation with `c()` no longer
+throws an error when given `NULL` elements.
+
 # psychTestR 2.0.2
 
 * Bugfix - Allowing `NULL` `researcher_email` argument in `test_options()`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# psychTestR 2.0.3
+
 * Bugfix - Implicit timeline creation with `c()` no longer
 throws an error when given `NULL` elements.
 

--- a/R/test-elements.R
+++ b/R/test-elements.R
@@ -23,6 +23,7 @@ is.test_element <- function(x) is(x, "test_element")
 #' @export
 c.test_element <- function(...) {
   input <- list(...)
+  input <- Filter(f = Negate(is.null), input)
   stopifnot(all(vapply(input, function(x) {
     is(x, "test_element") || is(x, "timeline") || is.list(x)
   }, logical(1))))


### PR DESCRIPTION
Bugfix - Implicit timeline creation with `c()` no longer throws an error when given `NULL` elements.