### PR TITLE
Fix get_user_info bug fix

### DIFF
--- a/R/state.R
+++ b/R/state.R
@@ -64,7 +64,7 @@ STATE <- R6::R6Class(
       allow_session_saving = TRUE,
       url_params = list(),
       allow_url_rewrite = as.logical(NA),
-      user_info = list()
+      user_info = FALSE
     )
   )
 )

--- a/R/state.R
+++ b/R/state.R
@@ -64,7 +64,7 @@ STATE <- R6::R6Class(
       allow_session_saving = TRUE,
       url_params = list(),
       allow_url_rewrite = as.logical(NA),
-      user_info = FALSE
+      user_info = as.logical(NA)
     )
   )
 )

--- a/R/state.R
+++ b/R/state.R
@@ -64,7 +64,7 @@ STATE <- R6::R6Class(
       allow_session_saving = TRUE,
       url_params = list(),
       allow_url_rewrite = as.logical(NA),
-      user_ip = as.character(NA)
+      user_info = list()
     )
   )
 )


### PR DESCRIPTION
I wonder if we want something else other than the default value to be FALSE for `user_info` (e.g., which matches the type of the object when `get_user_info` is TRUE? An empty list here causes a different problem, which I could look into more if desirable.