### PR TITLE
check for duplicates in the `key` column during initialisation of dicts

### DIFF
--- a/R/i18n.R
+++ b/R/i18n.R
@@ -105,6 +105,8 @@ i18n_check_df <- function(x) {
     stop("input to i18n_dict() must have exactly one character column called 'key")
   if (!all(sapply(x, is.character)))
     stop("all columns of input to i18n_dict() must be character class")
+  if (any(duplicated(x$key)))
+    warning("there are duplicates in the `key` column. Only the last occurence of each key will be kept")
 }
 
 i18n_state <- R6::R6Class(

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -106,7 +106,7 @@ i18n_check_df <- function(x) {
   if (!all(sapply(x, is.character)))
     stop("all columns of input to i18n_dict() must be character class")
   if (any(duplicated(x$key)))
-    warning("there are duplicates in the `key` column. Only the last occurence of each key will be kept")
+    stop("there are duplicates in the `key` column. Keys must be unique.")
 }
 
 i18n_state <- R6::R6Class(


### PR DESCRIPTION
When calling `i18n_dict$new()` on a data.frame with duplicates in the `key` column, only one instance of each key is kept in the resulting dictionary.
```{r}
library(psychTestR)
test_df <- data.frame(
  key = c("prompt", "button1", "button2", "button2"),
  en = c("To be, or not to be", "That is the question", "42", "Forty-two")
)
test_dict <-
  i18n_dict$new(test_df)
test_dict |>
  print()
```
```
i18n dictionary (3 terms):

      key                   en
1 button1 That is the question
2 button2            Forty-two
3  prompt  To be, or not to be
```
The PR contains a check for duplicated keys and adds a warning to `i18n_check_df()`.
Thanks, @sebsilas, for spotting that duplicates are silently dropped.